### PR TITLE
Add missing __METHOD__ to tableExists

### DIFF
--- a/src/TitleIndexUpdater.php
+++ b/src/TitleIndexUpdater.php
@@ -91,7 +91,7 @@ class TitleIndexUpdater implements
 	 */
 	private function insert( PageIdentity $page, $forceId = null ) {
 		$db = $this->lb->getConnection( DB_PRIMARY );
-		if ( !$db->tableExists( 'mws_title_index' ) ) {
+		if ( !$db->tableExists( 'mws_title_index', __METHOD__ ) ) {
 			return false;
 		}
 		if ( !$page->exists() ) {
@@ -128,7 +128,7 @@ class TitleIndexUpdater implements
 	private function delete( int $namespace, string $title ) {
 		$db = $this->lb->getConnection( DB_PRIMARY );
 		$db = $this->lb->getConnection( DB_PRIMARY );
-		if ( !$db->tableExists( 'mws_title_index' ) ) {
+		if ( !$db->tableExists( 'mws_title_index', __METHOD__ ) ) {
 			return false;
 		}
 		return $db->delete(


### PR DESCRIPTION
Without this, it causes log spam.

> SQL query did not specify the caller (guessed caller: MWStake\\MediaWiki\\Component\\CommonWebAPIs\\TitleIndexUpdater::insert)