### PR TITLE
Fix prefixed value in FileQueryStore

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -6,7 +6,7 @@ if ( defined( 'MWSTAKE_MEDIAWIKI_COMPONENT_COMMONWEBAPIS_VERSION' ) ) {
 	return;
 }
 
-define( 'MWSTAKE_MEDIAWIKI_COMPONENT_COMMONWEBAPIS_VERSION', '3.0.10' );
+define( 'MWSTAKE_MEDIAWIKI_COMPONENT_COMMONWEBAPIS_VERSION', '3.0.11' );
 
 MWStake\MediaWiki\ComponentLoader\Bootstrapper::getInstance()
 	->register( 'commonwebapis', static function () {

--- a/src/Data/FileQueryStore/SecondaryDataProvider.php
+++ b/src/Data/FileQueryStore/SecondaryDataProvider.php
@@ -46,7 +46,7 @@ class SecondaryDataProvider extends TitleSecondaryDataProvider {
 		$dataSets = parent::extend( $dataSets );
 		foreach ( $dataSets as $dataSet ) {
 			$title = $this->titleFromRecord( $dataSet );
-			$dataSet->set( TitleRecord::PAGE_PREFIXED, $title->getText() );
+			$dataSet->set( TitleRecord::PAGE_PREFIXED, $title->getPrefixedText() );
 			$file = $this->repoGroup->getLocalRepo()->newFile( $title );
 
 			$dataSet->set(


### PR DESCRIPTION
Without 'File:' thumbs are broken

ERM41095

[master]