### PR TITLE
Replace per-row permission checks with PermissionTrimmer

### DIFF
--- a/src/Data/CategoryQueryStore/PrimaryDataProvider.php
+++ b/src/Data/CategoryQueryStore/PrimaryDataProvider.php
@@ -48,4 +48,18 @@ class PrimaryDataProvider extends TitlePrimaryProvider {
 
 		return $conds;
 	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getTotal( ReaderParams $params ): int {
+		$params = CategoryReaderParams::newFromOtherReaderParams( $params );
+		$row = $this->db->selectRow(
+			[ 'mws_category_index', 'category' ],
+			[ 'COUNT(*) AS cnt' ],
+			$this->makePreFilterConds( $params ),
+			__METHOD__
+		);
+		return $row ? (int)$row->cnt : 0;
+	}
 }

--- a/src/Data/FileQueryStore/PrimaryDataProvider.php
+++ b/src/Data/FileQueryStore/PrimaryDataProvider.php
@@ -2,8 +2,6 @@
 
 namespace MWStake\MediaWiki\Component\CommonWebAPIs\Data\FileQueryStore;
 
-use MediaWiki\Context\RequestContext;
-use MediaWiki\Title\Title;
 use MWStake\MediaWiki\Component\CommonWebAPIs\Data\TitleQueryStore\PrimaryDataProvider as TitlePrimaryDataProvider;
 use MWStake\MediaWiki\Component\CommonWebAPIs\Data\TitleQueryStore\TitleRecord;
 use MWStake\MediaWiki\Component\DataStore\Filter;
@@ -172,10 +170,6 @@ class PrimaryDataProvider extends TitlePrimaryDataProvider {
 	 * @return void
 	 */
 	protected function appendRowToData( \stdClass $row ) {
-		$user = RequestContext::getMain()->getUser();
-		if ( !$this->permissionManager->userCan( 'read', $user, Title::newFromRow( $row ) ) ) {
-			return;
-		}
 		$this->data[] = new TitleRecord( (object)[
 			TitleRecord::PAGE_ID => (int)$row->mti_page_id,
 			TitleRecord::PAGE_NAMESPACE => NS_FILE,
@@ -251,6 +245,11 @@ class PrimaryDataProvider extends TitlePrimaryDataProvider {
 			}
 			$conds['ORDER BY'] .= "$property {$sort->getDirection()}";
 		}
+
+		if ( $params->getQuery() === '' && $params->getLimit() !== ReaderParams::LIMIT_INFINITE ) {
+			$conds['LIMIT'] = ( $params->getStart() + $params->getLimit() ) * static::OVERFETCH_FACTOR;
+		}
+
 		return $conds;
 	}
 
@@ -260,6 +259,21 @@ class PrimaryDataProvider extends TitlePrimaryDataProvider {
 	 */
 	protected function getDefaultOptions() {
 		return [ 'GROUP BY' => 'page_id' ];
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getTotal( ReaderParams $params ): int {
+		$row = $this->db->selectRow(
+			$this->getTableNames(),
+			[ 'COUNT(DISTINCT page_id) AS cnt' ],
+			$this->makePreFilterConds( $params ),
+			__METHOD__,
+			[],
+			$this->getJoinConds( $params )
+		);
+		return $row ? (int)$row->cnt : 0;
 	}
 
 	/**

--- a/src/Data/FileQueryStore/PrimaryDataProvider.php
+++ b/src/Data/FileQueryStore/PrimaryDataProvider.php
@@ -170,6 +170,7 @@ class PrimaryDataProvider extends TitlePrimaryDataProvider {
 	 * @return void
 	 */
 	protected function appendRowToData( \stdClass $row ) {
+		// Permission checks are performed in the "Trimmer" phase for performance reasons
 		$this->data[] = new TitleRecord( (object)[
 			TitleRecord::PAGE_ID => (int)$row->mti_page_id,
 			TitleRecord::PAGE_NAMESPACE => NS_FILE,

--- a/src/Data/FileQueryStore/Reader.php
+++ b/src/Data/FileQueryStore/Reader.php
@@ -7,7 +7,10 @@ use MediaWiki\Page\PageProps;
 use MediaWiki\Permissions\PermissionManager;
 use MediaWiki\Title\NamespaceInfo;
 use MediaWiki\Title\TitleFactory;
+use MWStake\MediaWiki\Component\CommonWebAPIs\Data\PermissionTrimmer;
+use MWStake\MediaWiki\Component\DataStore\ISecondaryDataProvider;
 use MWStake\MediaWiki\Component\DataStore\ReaderParams;
+use MWStake\MediaWiki\Component\DataStore\ResultSet;
 use Wikimedia\Rdbms\ILoadBalancer;
 
 class Reader extends \MWStake\MediaWiki\Component\DataStore\Reader {
@@ -78,5 +81,50 @@ class Reader extends \MWStake\MediaWiki\Component\DataStore\Reader {
 	public function makeSecondaryDataProvider() {
 		return new SecondaryDataProvider( $this->titleFactory, $this->language,
 			$this->pageProps, $this->repoGroup );
+	}
+
+	/**
+	 * @param ReaderParams $params
+	 * @return PermissionTrimmer
+	 */
+	protected function makeTrimmer( $params ) {
+		return new PermissionTrimmer(
+			$params->getLimit(),
+			$params->getStart(),
+			$this->permissionManager
+		);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function read( $params ) {
+		$primaryDataProvider = $this->makePrimaryDataProvider( $params );
+		$dataSets = $primaryDataProvider->makeData( $params );
+
+		$filterer = $this->makeFilterer( $params );
+		$dataSets = $filterer->filter( $dataSets );
+
+		if ( $params->getQuery() !== '' ) {
+			$total = count( $dataSets );
+		} else {
+			$total = $primaryDataProvider->getTotal( $params );
+		}
+
+		$sorter = $this->makeSorter( $params );
+		$dataSets = $sorter->sort(
+			$dataSets,
+			$this->getSchema()->getUnsortableFields()
+		);
+
+		$trimmer = $this->makeTrimmer( $params );
+		$dataSets = $trimmer->trim( $dataSets );
+
+		$secondaryDataProvider = $this->makeSecondaryDataProvider();
+		if ( $secondaryDataProvider instanceof ISecondaryDataProvider ) {
+			$dataSets = $secondaryDataProvider->extend( $dataSets );
+		}
+
+		return new ResultSet( $dataSets, $total );
 	}
 }

--- a/src/Data/PermissionTrimmer.php
+++ b/src/Data/PermissionTrimmer.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace MWStake\MediaWiki\Component\CommonWebAPIs\Data;
+
+use MediaWiki\Context\RequestContext;
+use MediaWiki\Permissions\PermissionManager;
+use MediaWiki\Title\Title;
+use MWStake\MediaWiki\Component\CommonWebAPIs\Data\TitleQueryStore\TitleRecord;
+use MWStake\MediaWiki\Component\DataStore\ITrimmer;
+use MWStake\MediaWiki\Component\DataStore\ReaderParams;
+use MWStake\MediaWiki\Component\DataStore\Record;
+
+/**
+ * A trimmer that combines permission filtering with pagination.
+ *
+ * Instead of checking permissions on ALL records and then trimming,
+ * this iterates through the sorted dataset and collects only permitted
+ * records until the page is filled.
+ */
+class PermissionTrimmer implements ITrimmer {
+	/** @var int */
+	private $limit;
+
+	/** @var int */
+	private $offset;
+
+	/** @var PermissionManager */
+	private $permissionManager;
+
+	/**
+	 * @param int $limit
+	 * @param int $offset
+	 * @param PermissionManager $permissionManager
+	 */
+	public function __construct( int $limit, int $offset, PermissionManager $permissionManager ) {
+		$this->limit = $limit;
+		$this->offset = $offset;
+		$this->permissionManager = $permissionManager;
+	}
+
+	/**
+	 * @param Record[] $dataSets
+	 * @return Record[]
+	 */
+	public function trim( $dataSets ) {
+		$user = RequestContext::getMain()->getUser();
+		$result = [];
+		$permittedCount = 0;
+
+		foreach ( $dataSets as $record ) {
+			if ( !$this->canRead( $record, $user ) ) {
+				continue;
+			}
+			$permittedCount++;
+			if ( $permittedCount <= $this->offset ) {
+				continue;
+			}
+			$result[] = $record;
+			if ( $this->limit !== ReaderParams::LIMIT_INFINITE && count( $result ) >= $this->limit ) {
+				break;
+			}
+		}
+
+		return $result;
+	}
+
+	/**
+	 * @param Record $record
+	 * @param \MediaWiki\User\User $user
+	 * @return bool
+	 */
+	private function canRead( Record $record, $user ): bool {
+		$ns = $record->get( TitleRecord::PAGE_NAMESPACE );
+		$dbKey = $record->get( TitleRecord::PAGE_DBKEY );
+		if ( $ns === null || $dbKey === null ) {
+			return true;
+		}
+		$title = Title::makeTitle( $ns, $dbKey );
+		if ( !$title ) {
+			return true;
+		}
+		return $this->permissionManager->userCan( 'read', $user, $title );
+	}
+}

--- a/src/Data/TitleQueryStore/PrimaryDataProvider.php
+++ b/src/Data/TitleQueryStore/PrimaryDataProvider.php
@@ -2,11 +2,9 @@
 
 namespace MWStake\MediaWiki\Component\CommonWebAPIs\Data\TitleQueryStore;
 
-use MediaWiki\Context\RequestContext;
 use MediaWiki\Language\Language;
 use MediaWiki\Permissions\PermissionManager;
 use MediaWiki\Title\NamespaceInfo;
-use MediaWiki\Title\Title;
 use MWStake\MediaWiki\Component\DataStore\Filter;
 use MWStake\MediaWiki\Component\DataStore\PrimaryDatabaseDataProvider;
 use MWStake\MediaWiki\Component\DataStore\ReaderParams;
@@ -18,6 +16,12 @@ use Wikimedia\Rdbms\ResultWrapper;
  * @stable to extend
  */
 class PrimaryDataProvider extends PrimaryDatabaseDataProvider {
+
+	/**
+	 * Factor by which to over-fetch rows from the database to account for
+	 * rows that may be filtered out by permission checks.
+	 */
+	protected const OVERFETCH_FACTOR = 5;
 
 	/** @var Language */
 	protected $language;
@@ -307,11 +311,6 @@ class PrimaryDataProvider extends PrimaryDatabaseDataProvider {
 	 * @return void
 	 */
 	protected function appendRowToData( \stdClass $row ) {
-		$user = RequestContext::getMain()->getUser();
-		if ( !$this->permissionManager->userCan( 'read', $user, Title::newFromRow( $row ) ) ) {
-			return;
-		}
-
 		$this->data[] = new TitleRecord( (object)[
 			TitleRecord::PAGE_ID => (int)$row->mti_page_id,
 			TitleRecord::PAGE_NAMESPACE => (int)$row->page_namespace,
@@ -325,6 +324,37 @@ class PrimaryDataProvider extends PrimaryDatabaseDataProvider {
 			TitleRecord::BASE_TITLE => '',
 			'_score' => $row->_score ?? 0
 		] );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected function makePreOptionConds( ReaderParams $params ) {
+		$conds = parent::makePreOptionConds( $params );
+		// Only apply SQL LIMIT when there is no free-text query,
+		// because reranking requires the full result set.
+		if ( $params->getQuery() === '' && $params->getLimit() !== ReaderParams::LIMIT_INFINITE ) {
+			$conds['LIMIT'] = ( $params->getStart() + $params->getLimit() ) * static::OVERFETCH_FACTOR;
+		}
+		return $conds;
+	}
+
+	/**
+	 * Get the total count of records matching the current filters (without LIMIT).
+	 *
+	 * @param ReaderParams $params
+	 * @return int
+	 */
+	public function getTotal( ReaderParams $params ): int {
+		$row = $this->db->selectRow(
+			$this->getTableNames(),
+			[ 'COUNT(*) AS cnt' ],
+			$this->makePreFilterConds( $params ),
+			__METHOD__,
+			[],
+			$this->getJoinConds( $params )
+		);
+		return $row ? (int)$row->cnt : 0;
 	}
 
 	/**

--- a/src/Data/TitleQueryStore/PrimaryDataProvider.php
+++ b/src/Data/TitleQueryStore/PrimaryDataProvider.php
@@ -311,6 +311,7 @@ class PrimaryDataProvider extends PrimaryDatabaseDataProvider {
 	 * @return void
 	 */
 	protected function appendRowToData( \stdClass $row ) {
+		// Permission checks are performed in the "Trimmer" phase for performance reasons
 		$this->data[] = new TitleRecord( (object)[
 			TitleRecord::PAGE_ID => (int)$row->mti_page_id,
 			TitleRecord::PAGE_NAMESPACE => (int)$row->page_namespace,

--- a/src/Data/TitleQueryStore/Reader.php
+++ b/src/Data/TitleQueryStore/Reader.php
@@ -7,7 +7,10 @@ use MediaWiki\Page\PageProps;
 use MediaWiki\Permissions\PermissionManager;
 use MediaWiki\Title\NamespaceInfo;
 use MediaWiki\Title\TitleFactory;
+use MWStake\MediaWiki\Component\CommonWebAPIs\Data\PermissionTrimmer;
+use MWStake\MediaWiki\Component\DataStore\ISecondaryDataProvider;
 use MWStake\MediaWiki\Component\DataStore\ReaderParams;
+use MWStake\MediaWiki\Component\DataStore\ResultSet;
 use Wikimedia\Rdbms\ILoadBalancer;
 
 /*
@@ -52,7 +55,7 @@ class Reader extends \MWStake\MediaWiki\Component\DataStore\Reader {
 	}
 
 	/**
-	 * @return UserSchema
+	 * @return TitleSchema
 	 */
 	public function getSchema() {
 		return new TitleSchema();
@@ -75,5 +78,52 @@ class Reader extends \MWStake\MediaWiki\Component\DataStore\Reader {
 	 */
 	public function makeSecondaryDataProvider() {
 		return new SecondaryDataProvider( $this->titleFactory, $this->language, $this->pageProps );
+	}
+
+	/**
+	 * @param ReaderParams $params
+	 * @return PermissionTrimmer
+	 */
+	protected function makeTrimmer( $params ) {
+		return new PermissionTrimmer(
+			$params->getLimit(),
+			$params->getStart(),
+			$this->permissionManager
+		);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function read( $params ) {
+		$primaryDataProvider = $this->makePrimaryDataProvider( $params );
+		$dataSets = $primaryDataProvider->makeData( $params );
+
+		$filterer = $this->makeFilterer( $params );
+		$dataSets = $filterer->filter( $dataSets );
+
+		// Use a separate COUNT query for accurate total (pre-permission).
+		// When a query is set, reranking may exclude rows, so use the in-memory count.
+		if ( $params->getQuery() !== '' ) {
+			$total = count( $dataSets );
+		} else {
+			$total = $primaryDataProvider->getTotal( $params );
+		}
+
+		$sorter = $this->makeSorter( $params );
+		$dataSets = $sorter->sort(
+			$dataSets,
+			$this->getSchema()->getUnsortableFields()
+		);
+
+		$trimmer = $this->makeTrimmer( $params );
+		$dataSets = $trimmer->trim( $dataSets );
+
+		$secondaryDataProvider = $this->makeSecondaryDataProvider();
+		if ( $secondaryDataProvider instanceof ISecondaryDataProvider ) {
+			$dataSets = $secondaryDataProvider->extend( $dataSets );
+		}
+
+		return new ResultSet( $dataSets, $total );
 	}
 }

--- a/src/Data/TitleTreeStore/PrimaryDataProvider.php
+++ b/src/Data/TitleTreeStore/PrimaryDataProvider.php
@@ -89,6 +89,7 @@ class PrimaryDataProvider extends \MWStake\MediaWiki\Component\CommonWebAPIs\Dat
 	protected function appendRowToData( \stdClass $row ) {
 		$indexTitle = $row->mti_title;
 		$uniqueId = $this->getUniqueId( $row );
+		// Permission checks are performed in the "Trimmer" phase for performance reasons
 
 		if ( $this->isSubpage( $indexTitle ) &&
 			$this->nsInfo->hasSubpages( (int)$row->page_namespace ) ) {

--- a/src/Data/TitleTreeStore/PrimaryDataProvider.php
+++ b/src/Data/TitleTreeStore/PrimaryDataProvider.php
@@ -2,11 +2,9 @@
 
 namespace MWStake\MediaWiki\Component\CommonWebAPIs\Data\TitleTreeStore;
 
-use MediaWiki\Context\RequestContext;
 use MediaWiki\Language\Language;
 use MediaWiki\Permissions\PermissionManager;
 use MediaWiki\Title\NamespaceInfo;
-use MediaWiki\Title\Title;
 use MWStake\MediaWiki\Component\DataStore\ReaderParams;
 use MWStake\MediaWiki\Component\DataStore\Schema;
 use Wikimedia\Rdbms\IDatabase;
@@ -91,11 +89,6 @@ class PrimaryDataProvider extends \MWStake\MediaWiki\Component\CommonWebAPIs\Dat
 	protected function appendRowToData( \stdClass $row ) {
 		$indexTitle = $row->mti_title;
 		$uniqueId = $this->getUniqueId( $row );
-
-		$user = RequestContext::getMain()->getUser();
-		if ( !$this->permissionManager->userCan( 'read', $user, Title::newFromRow( $row ) ) ) {
-			return;
-		}
 
 		if ( $this->isSubpage( $indexTitle ) &&
 			$this->nsInfo->hasSubpages( (int)$row->page_namespace ) ) {


### PR DESCRIPTION
Move permission filtering from PrimaryDataProvider::appendRowToData()
(which checked ALL rows) to a new PermissionTrimmer that only checks
records needed to fill the requested page.

- New PermissionTrimmer implements ITrimmer interface
- SQL LIMIT with 5x overfetch for non-query requests
- Separate COUNT(*) query for accurate total
- Permission checks reduced from O(N) to O(limit + offset + rejected)

Breaking changes:
- `total` field is now pre-permission count (approximate)
- Subclasses overriding appendRowToData() for permission must adapt

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

ERM46614
[?.?.?]