### PR TITLE
Fix IcuCollation exception on certain wiki base langs

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -7,7 +7,7 @@ if ( defined( 'MWSTAKE_MEDIAWIKI_COMPONENT_COMMONWEBAPIS_VERSION' ) ) {
 	return;
 }
 
-define( 'MWSTAKE_MEDIAWIKI_COMPONENT_COMMONWEBAPIS_VERSION', '4.0.2' );
+define( 'MWSTAKE_MEDIAWIKI_COMPONENT_COMMONWEBAPIS_VERSION', '4.0.3' );
 
 MWStake\MediaWiki\ComponentLoader\Bootstrapper::getInstance()
 	->register( 'commonwebapis', static function () {

--- a/src/ContentLanguageCollationTrait.php
+++ b/src/ContentLanguageCollationTrait.php
@@ -29,7 +29,8 @@ trait ContentLanguageCollationTrait {
 			try {
 				$c = $collationFactory->makeCollation( 'uca-' . $candidate );
 				$c->getFirstLetter( 'a' );
-				return $this->resolvedCollation = $c;
+				$this->resolvedCollation = $c;
+				return $c;
 			} catch ( \RuntimeException $e ) {
 				continue;
 			}
@@ -38,6 +39,7 @@ trait ContentLanguageCollationTrait {
 		// should never reach here though
 		$fallback = $collationFactory->makeCollation( 'uca-en' );
 		$fallback->getFirstLetter( 'a' );
-		return $this->resolvedCollation = $fallback;
+		$this->resolvedCollation = $fallback;
+		return $fallback;
 	}
 }

--- a/src/ContentLanguageCollationTrait.php
+++ b/src/ContentLanguageCollationTrait.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace MWStake\MediaWiki\Component\CommonWebAPIs;
+
+use Collation;
+use MediaWiki\Collation\CollationFactory;
+use MediaWiki\Language\Language;
+
+trait ContentLanguageCollationTrait {
+	private ?Collation $resolvedCollation = null;
+
+	protected function resolveCollation(
+		CollationFactory $collationFactory,
+		Language $contentLanguage
+	): Collation {
+		if ( $this->resolvedCollation ) {
+			return $this->resolvedCollation;
+		}
+
+		$languageFallback = \MediaWiki\MediaWikiServices::getInstance()->getLanguageFallback();
+		$code = $contentLanguage->getCode();
+		$normalized = preg_replace( '/-(formal|informal)$/i', '', $code ) ?: $code;
+
+		$candidates = array_values( array_unique(
+			array_merge( [ $normalized ], $languageFallback->getAll( $normalized ) )
+		) );
+
+		foreach ( $candidates as $candidate ) {
+			try {
+				$c = $collationFactory->makeCollation( 'uca-' . $candidate );
+				$c->getFirstLetter( 'a' );
+				return $this->resolvedCollation = $c;
+			} catch ( \RuntimeException $e ) {
+				continue;
+			}
+		}
+
+		// should never reach here though
+		$fallback = $collationFactory->makeCollation( 'uca-en' );
+		$fallback->getFirstLetter( 'a' );
+		return $this->resolvedCollation = $fallback;
+	}
+}

--- a/src/Data/TitleTreeStore/SortkeyBucketProvider.php
+++ b/src/Data/TitleTreeStore/SortkeyBucketProvider.php
@@ -5,9 +5,11 @@ namespace MWStake\MediaWiki\Component\CommonWebAPIs\Data\TitleTreeStore;
 use Collation;
 use MediaWiki\Collation\CollationFactory;
 use MediaWiki\Language\Language;
+use MWStake\MediaWiki\Component\CommonWebAPIs\ContentLanguageCollationTrait;
 use MWStake\MediaWiki\Component\CommonWebAPIs\Data\TitleQueryStore\TitleRecord;
 
 class SortkeyBucketProvider {
+	use ContentLanguageCollationTrait;
 
 	/** @var Collation */
 	private $collation;
@@ -17,7 +19,7 @@ class SortkeyBucketProvider {
 	 * @param Language $contentLanguage
 	 */
 	public function __construct( CollationFactory $collationFactory, Language $contentLanguage ) {
-		$this->collation = $collationFactory->makeCollation( 'uca-' . $contentLanguage->getCode() );
+		$this->collation = $this->resolveCollation( $collationFactory, $contentLanguage );
 	}
 
 	/**

--- a/src/Maintenance/PopulateTitleIndex.php
+++ b/src/Maintenance/PopulateTitleIndex.php
@@ -26,9 +26,26 @@ class PopulateTitleIndex extends LoggedUpdateMaintenance {
 			[ 'pp' => [ 'LEFT OUTER JOIN', [ 'p.page_id = pp.pp_page', 'pp.pp_propname' => 'displaytitle' ] ] ]
 		);
 
+		// Same as logic of ContentLanguageCollationTrait, added in this way
+		// because a maintenance script does not always run well with traits,
+		// especially when not called using run.php + class name
 		$collationFactory = $this->getServiceContainer()->getCollationFactory();
-		$contentLanguage = $this->getServiceContainer()->getContentLanguage();
-		$collation = $collationFactory->makeCollation( 'uca-' . $contentLanguage->getCode() );
+		$languageFallback = $this->getServiceContainer()->getLanguageFallback();
+		$languageCode = $this->getServiceContainer()->getContentLanguage()->getCode();
+		// getAll() in MESSAGES mode always terminates with 'en', so this loop always finds a match
+		$candidates = array_merge( [ $languageCode ], $languageFallback->getAll( $languageCode ) );
+		$collation = null;
+		foreach ( $candidates as $candidate ) {
+			try {
+				$c = $collationFactory->makeCollation( 'uca-' . $candidate );
+				// triggers fetchFirstLetterData() to validate the locale
+				$c->getFirstLetter( 'a' );
+				$collation = $c;
+				break;
+			} catch ( \RuntimeException $e ) {
+				// locale not in TAILORING_FIRST_LETTERS, try next fallback
+			}
+		}
 
 		$toInsert = [];
 		$cnt = 0;

--- a/src/Maintenance/PopulateTitleIndex.php
+++ b/src/Maintenance/PopulateTitleIndex.php
@@ -46,9 +46,12 @@ class PopulateTitleIndex extends LoggedUpdateMaintenance {
 				break;
 			} catch ( \RuntimeException $e ) {
 				// locale not in TAILORING_FIRST_LETTERS, try next fallback
+				continue;
 			}
-			// should never reach here
+		}
+		if ( $collation === null ) {
 			$collation = $collationFactory->makeCollation( 'uca-en' );
+			$collation->getFirstLetter( 'a' );
 		}
 
 		$toInsert = [];

--- a/src/Maintenance/PopulateTitleIndex.php
+++ b/src/Maintenance/PopulateTitleIndex.php
@@ -31,9 +31,11 @@ class PopulateTitleIndex extends LoggedUpdateMaintenance {
 		// especially when not called using run.php + class name
 		$collationFactory = $this->getServiceContainer()->getCollationFactory();
 		$languageFallback = $this->getServiceContainer()->getLanguageFallback();
-		$languageCode = $this->getServiceContainer()->getContentLanguage()->getCode();
-		// getAll() in MESSAGES mode always terminates with 'en', so this loop always finds a match
-		$candidates = array_merge( [ $languageCode ], $languageFallback->getAll( $languageCode ) );
+		$code = $this->getServiceContainer()->getContentLanguage()->getCode();
+		$normalized = preg_replace( '/-(formal|informal)$/i', '', $code ) ?: $code;
+		$candidates = array_values( array_unique(
+			array_merge( [ $normalized ], $languageFallback->getAll( $normalized ) )
+		) );
 		$collation = null;
 		foreach ( $candidates as $candidate ) {
 			try {
@@ -45,6 +47,8 @@ class PopulateTitleIndex extends LoggedUpdateMaintenance {
 			} catch ( \RuntimeException $e ) {
 				// locale not in TAILORING_FIRST_LETTERS, try next fallback
 			}
+			// should never reach here
+			$collation = $collationFactory->makeCollation( 'uca-en' );
 		}
 
 		$toInsert = [];

--- a/src/TitleIndexUpdater.php
+++ b/src/TitleIndexUpdater.php
@@ -26,6 +26,7 @@ class TitleIndexUpdater implements
 	PageUndeleteCompleteHook,
 	AfterImportPageHook
 {
+	use ContentLanguageCollationTrait;
 
 	/**
 	 * @var ILoadBalancer
@@ -202,7 +203,7 @@ class TitleIndexUpdater implements
 	 */
 	private function getFirstLetter( string $dbkey ): string {
 		$title = str_replace( '_', ' ', explode( '/', $dbkey )[0] );
-		$collation = $this->collationFactory->makeCollation( 'uca-' . $this->contentLanguage->getCode() );
+		$collation = $this->resolveCollation( $this->collationFactory, $this->contentLanguage );
 		$letter = $collation->getFirstLetter( $title );
 
 		if ( $letter === '' ) {


### PR DESCRIPTION
When wiki is using base language like
`de-formal` (not a supported ICU locale),
exception of IcuCollation can break several
things, include wiki installation, update,
render of Special:Pages and Special:Filelist.

ERM48253

[5.1.x]